### PR TITLE
Minor change to the order of execution

### DIFF
--- a/first_install.sh
+++ b/first_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
-sudo mkdir /opt/firefox
-bash ./firefox_update.sh
+sudo mkdir -p /opt/firefox
 sudo mv /usr/bin/firefox /usr/bin/firefox.old
+bash ./firefox_update.sh
 sudo ln -s /opt/firefox/firefox/firefox /usr/bin/firefox
 sudo cp ./firefox.desktop /usr/share/applications/firefox.desktop


### PR DESCRIPTION
Add the extra "-p" flag to guarantee the whole path is created, and moves the old Firefox executable before the installation. 